### PR TITLE
Config parser fix

### DIFF
--- a/skosify/config.py
+++ b/skosify/config.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import argparse
 from rdflib import URIRef, Namespace, RDF, RDFS
+from rdflib.namespace import ClosedNamespace
 
 # import for both Python 2 and Python 3
 try:
@@ -132,7 +133,11 @@ def expand_curielike(namespaces, curie):
         return curie
 
     if ns in namespaces:
-        return URIRef(namespaces[ns].term(localpart))
+        nsvalue = namespaces[ns]
+        try:
+            return URIRef(nsvalue.term(localpart))
+        except Exception:
+            return URIRef(str(nsvalue) + localpart)
     else:
         logging.warning("Unknown namespace prefix %s", ns)
         return URIRef(curie)

--- a/skosify/config.py
+++ b/skosify/config.py
@@ -5,7 +5,6 @@ import logging
 import sys
 import argparse
 from rdflib import URIRef, Namespace, RDF, RDFS
-from rdflib.namespace import ClosedNamespace
 
 # import for both Python 2 and Python 3
 try:


### PR DESCRIPTION
Fixes a bug that causes config file reading to crash when a non existing ClosedNamespace is parsed. This can be replicated by parsing the following line: 
`rdfs.comment_EN=rdfs:comment`

Additionally, fixes an issue where `namespaces[ns].term(localpart)` line fails because the presumed namespace (can also be eg. URIRef at interpretation time) does not either have a term function or fails. 