### PR TITLE
Allow sections to be skipped in skosify.cfg

### DIFF
--- a/skosify/config.py
+++ b/skosify/config.py
@@ -7,6 +7,7 @@ import argparse
 from rdflib import URIRef, Namespace, RDF, RDFS
 from io import StringIO
 from textwrap import dedent
+from copy import copy
 
 # import for both Python 2 and Python 3
 try:
@@ -68,7 +69,7 @@ class Config(object):
         self.relations = {}
 
         # namespaces
-        self.namespaces = DEFAULT_NAMESPACES
+        self.namespaces = copy(DEFAULT_NAMESPACES)
 
         if file is not None:
             self.read_file(file)

--- a/skosify/config.py
+++ b/skosify/config.py
@@ -78,7 +78,10 @@ class Config(object):
 
         # complains if open failed
         with open(filename) as fp:
-            cfgparser.readfp(fp)
+            if sys.version_info >= (3, 2):
+                cfgparser.read_file(fp)  # Added in Python 3.2
+            else:
+                cfgparser.readfp(fp)  # Deprecated since Python 3.2
 
         # parse namespaces from configuration file
         for prefix, uri in cfgparser.items('namespaces'):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ def test_config(caplog):
     assert config['narrower'] is True
 
     assert config['namespaces']['dcmitype'] == URIRef('http://purl.org/dc/dcmitype/')
+    assert set(config['namespaces'].keys()) == set(['owl', 'rdf', 'xsd', 'rdfs', 'dct', 'skos', 'dc', 'dcmitype'])
 
     # TODO: types, literals, relations
 
@@ -25,6 +26,7 @@ def test_empty_config_file():
     cfg = StringIO()
     cfg.write(u'')
     config = skosify.config(cfg)
+    assert set(config['namespaces'].keys()) == set(['owl', 'rdf', 'xsd', 'rdfs', 'dct', 'skos', 'dc'])
     cfg.close()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 import unittest
 import pytest
 import logging
-
+from io import StringIO
 from rdflib import URIRef, Namespace
 
 import skosify
@@ -19,6 +19,13 @@ def test_config(caplog):
     assert config['namespaces']['dcmitype'] == URIRef('http://purl.org/dc/dcmitype/')
 
     # TODO: types, literals, relations
+
+
+def test_empty_config_file():
+    cfg = StringIO()
+    cfg.write(u'')
+    config = skosify.config(cfg)
+    cfg.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes all sections optional. Plus, use `configparser. read_file` on newer Python versions to avoid DeprecationWarning in python 3.6