### PR TITLE
Fix: Read to_format from config

### DIFF
--- a/skosify/cli.py
+++ b/skosify/cli.py
@@ -202,7 +202,6 @@ def main():
         logging.basicConfig(format=logformat, level=loglevel)
 
     output = options.output
-    to_format = options.to_format
 
     # read config file as defaults and override from command line arguments
     if options.config is not None:
@@ -218,7 +217,7 @@ def main():
         inputfiles = ['-']
 
     voc = skosify(*inputfiles, **vars(config))
-    write_rdf(voc, output, to_format)
+    write_rdf(voc, output, config.to_format)
 
 
 if __name__ == '__main__':

--- a/skosify/config.py
+++ b/skosify/config.py
@@ -56,6 +56,7 @@ class Config(object):
 
         # default options
         self.from_format = None
+        self.to_format = None
         self.mark_top_concepts = True
         self.narrower = True
         self.transitive = False


### PR DESCRIPTION
For consistency, I think it's good if to_format can also be read from the config file