### PR TITLE
Fix RDFlib 5 compatibility issue

### DIFF
--- a/skosify/skosify.py
+++ b/skosify/skosify.py
@@ -68,7 +68,7 @@ def in_general_ns(uri):
     RDFSuri = RDFS.uri
 
     for ns in (RDFuri, RDFSuri, OWL, SKOS, DC):
-        if uri.startswith(ns):
+        if uri.startswith(str(ns)):
             return True
     return False
 


### PR DESCRIPTION
Small fix for

    TypeError: startswith first arg must be str or a tuple of str, not ClosedNamespace

which started appearing after upgrading to RDFLib 5. Or more specifically, after SKOS was changed to a ClosedNamespace here: https://github.com/RDFLib/rdflib/commit/384c60367e945c2ac4e6f56eab394b43bed4c6c9