### PR TITLE
loop hierarchically redundant relations in a sorted fashion; unifies …

### DIFF
--- a/skosify/check.py
+++ b/skosify/check.py
@@ -92,8 +92,8 @@ def hierarchical_redundancy(rdf, fix=False):
     :param bool fix: Fix the problem by removing skos:broader relations between
         concepts that are otherwise connected by skos:broaderTransitive.
     """
-    for conc, parent1 in rdf.subject_objects(SKOS.broader):
-        for parent2 in rdf.objects(conc, SKOS.broader):
+    for conc, parent1 in sorted(rdf.subject_objects(SKOS.broader)):
+        for parent2 in sorted(rdf.objects(conc, SKOS.broader)):
             if parent1 == parent2:
                 continue  # must be different
             if parent2 in rdf.transitive_objects(parent1, SKOS.broader):


### PR DESCRIPTION
…logging output

This PR will fix the order of processing hierarchically redundant relations and, thus, fixes the issue of changing logging output as one can see from e.g., [here](https://github.com/NatLibFi/Finto-data/commit/58d50e663073651a9586fd16ea2d86f5a2e89dcb#diff-5a1cb199630cc239233542fc47e13571).

Similarly styled sorting is already done for multiple functions.