### PR TITLE
Write encoded output to stdout.buffer, as required by Python 3

### DIFF
--- a/skosify/rdftools/io.py
+++ b/skosify/rdftools/io.py
@@ -46,7 +46,9 @@ def read_rdf(sources, infmt):
 
 def write_rdf(rdf, filename, fmt):
     if filename == '-':
-        out = sys.stdout
+        # In Python 3 raw bytes must be written to stdout.buffer
+        # This works in Python 2.7 as well
+        out = sys.stdout.buffer
     else:
         out = open(filename, 'wb')
 


### PR DESCRIPTION
There is a problem writing RDF/XML output to stdout under Python 3:

```
$ skosify examples/milk.in.ttl 
WARNING: Concept scheme has no label(s). Use --label option to set the concept scheme label.
INFO: Marking loose concept http://example.org/animal as top concept of scheme http://example.org/scheme
INFO: Marking loose concept http://example.org/milk as top concept of scheme http://example.org/scheme
Traceback (most recent call last):
  File "/home/local/oisuomin/git/Skosify/venv/bin/skosify", line 11, in <module>
    load_entry_point('skosify', 'console_scripts', 'skosify')()
  File "/home/local/oisuomin/git/Skosify/skosify/cli.py", line 220, in main
    write_rdf(voc, output, config.to_format)
  File "/home/local/oisuomin/git/Skosify/skosify/rdftools/io.py", line 64, in write_rdf
    rdf.serialize(destination=out, format=fmt)
  File "/home/local/oisuomin/git/Skosify/venv/lib/python3.7/site-packages/rdflib/graph.py", line 947, in serialize
    serializer.serialize(stream, base=base, encoding=encoding, **args)
  File "/home/local/oisuomin/git/Skosify/venv/lib/python3.7/site-packages/rdflib/plugins/serializers/rdfxml.py", line 55, in serialize
    write('<?xml version="1.0" encoding="%s"?>\n' % self.encoding)
  File "/home/local/oisuomin/git/Skosify/venv/lib/python3.7/site-packages/rdflib/plugins/serializers/rdfxml.py", line 52, in <lambda>
    uni.encode(encoding, 'replace'))
TypeError: write() argument must be str, not bytes
```

The problem is that under Python 3, `sys.stdout` doesn't accept writing `bytes`. `sys.stdout.buffer` should be used instead. This works also under Python 2.7 so it should be safe to switch.

Unfortunately this part of the codebase doesn't have unit tests.