### PR TITLE
New preflabel policies "uppercase" and "lowercase" plus combinations

### DIFF
--- a/skosify/cli.py
+++ b/skosify/cli.py
@@ -81,7 +81,9 @@ def get_option_parser(defaults):
     group.add_option('-p', '--preflabel-policy', type='string',
                      help='Policy for handling multiple prefLabels '
                           'with the same language tag. '
-                          'Possible values: shortest, longest, all.')
+                          'Possible values: shortest, longest, lowercase, '
+                          'uppercase, all. Can also be a comma-separated list '
+                          'of policies to apply in order.')
     group.add_option('--set-modified', dest="set_modified",
                      action="store_true",
                      help='Set modification date on the ConceptScheme')

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -115,3 +115,61 @@ def test_preflabel_uniqueness():
     assert (a, SKOS.prefLabel, Literal('short', 'en')) in rdf
     assert (a, SKOS.prefLabel, Literal('short', 'nb')) in rdf
     assert (a, SKOS.altLabel, Literal('longer', 'en')) in rdf
+
+
+def test_preflabel_uniqueness_longest():
+    rdf = Graph()
+    a = BNode()
+
+    rdf.add((a, RDF.type, SKOS.Concept))
+    rdf.add((a, SKOS.prefLabel, Literal('short', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('longer', 'en')))  # keep
+    rdf.add((a, SKOS.prefLabel, Literal('short', 'nb')))  # keep
+
+    len_before = len(rdf)
+
+    skosify.check.preflabel_uniqueness(rdf, policy='longest')
+    assert len(rdf) == len_before
+    assert (a, SKOS.prefLabel, Literal('short', 'nb')) in rdf
+    assert (a, SKOS.prefLabel, Literal('longer', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('short', 'en')) in rdf
+
+
+def test_preflabel_uniqueness_shortest_lowercase():
+    rdf = Graph()
+    a = BNode()
+
+    rdf.add((a, RDF.type, SKOS.Concept))
+    rdf.add((a, SKOS.prefLabel, Literal('short', 'en')))  # keep
+    rdf.add((a, SKOS.prefLabel, Literal('Short', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('longer', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('Longer', 'en')))  # remove
+
+    len_before = len(rdf)
+
+    skosify.check.preflabel_uniqueness(rdf, policy=['shortest', 'lowercase'])
+    assert len(rdf) == len_before
+    assert (a, SKOS.prefLabel, Literal('short', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Short', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('longer', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Longer', 'en')) in rdf
+
+
+def test_preflabel_uniqueness_shortest_uppercase():
+    rdf = Graph()
+    a = BNode()
+
+    rdf.add((a, RDF.type, SKOS.Concept))
+    rdf.add((a, SKOS.prefLabel, Literal('short', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('Short', 'en')))  # keep
+    rdf.add((a, SKOS.prefLabel, Literal('longer', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('Longer', 'en')))  # remove
+
+    len_before = len(rdf)
+
+    skosify.check.preflabel_uniqueness(rdf, policy=['shortest', 'uppercase'])
+    assert len(rdf) == len_before
+    assert (a, SKOS.prefLabel, Literal('Short', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('short', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('longer', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Longer', 'en')) in rdf


### PR DESCRIPTION
When Skosify detects that a concept has >1 prefLabels in a particular language, it can select one as the real prefLabel and turn others into altLabels. The determination is based by the preflabel-policy setting which until now has supported the values `longest`, `shortest` and `all` (keep them all, just warn).

This PR adds two new policies `uppercase` and `lowercase` to prefer the prefLabel whose first character is either uppercase or lowercase.

These are not terribly useful on their own, but it is now possible to also combine the policies e.g. `shortest,lowercase` will select the shortest one, but in case of a tie, will prefer the label which starts with a lowercase character.

(The use case is selecting Finnish and Swedish names for languages in Lexvo: we would like to prefer the shortest language name with a lower case first letter, e.g. "englanti" instead of "Englannin kieli" and "engelska" instead of "Engelska")

Includes new unit tests :)