### PR TITLE
Work around N-Triples parser issue by using N3 parser instead

### DIFF
--- a/skosify/rdftools/io.py
+++ b/skosify/rdftools/io.py
@@ -5,6 +5,7 @@ import logging
 import sys
 
 from rdflib import Graph
+from rdflib.util import guess_format
 
 
 def read_rdf(sources, infmt):
@@ -30,13 +31,15 @@ def read_rdf(sources, infmt):
             fmt = infmt
         else:
             # determine format based on file extension
-            fmt = 'xml'  # default
-            if source.endswith('n3'):
-                fmt = 'n3'
-            if source.endswith('ttl'):
-                fmt = 'n3'
-            if source.endswith('nt'):
-                fmt = 'nt'
+            fmt = guess_format(source)
+            if not fmt:
+                fmt = 'xml'  # default
+
+        if fmt == 'nt' and sys.version_info[0] >= 3:
+            # Avoid using N-Triples parser on Python 3
+            # due to rdflib issue https://github.com/RDFLib/rdflib/issues/1144
+            # A workaround is to use N3 parser instead
+            fmt = 'n3'
 
         logging.debug("Parsing input file %s (format: %s)", source, fmt)
         rdf.parse(f, format=fmt)


### PR DESCRIPTION
There is a [known problem](https://github.com/RDFLib/rdflib/issues/1144) parsing N-Triples data from file objects in rdflib 5.0.0. It has [already been fixed](https://github.com/RDFLib/rdflib/pull/1145) in rdflib master, but the fix is not yet in a release, so it still affects Skosify:

```
# example.nt contains just one triple
$ skosify example.nt
CRITICAL: Parsing failed. Exception: can't concat str to bytes

# empty files cannot be parsed either
$ skosify empty.nt
CRITICAL: Parsing failed. Exception: can't concat str to bytes
```

The PR works around this by using the N3 parser instead for N-Triples files.

In addition, this PR switches to rdflib.util.guess_format instead of custom format selection logic.