### PR TITLE
introduce alphanumerical sorting policy; fixes #81

### DIFF
--- a/test/test_check.py
+++ b/test/test_check.py
@@ -173,3 +173,53 @@ def test_preflabel_uniqueness_shortest_uppercase():
     assert (a, SKOS.altLabel, Literal('short', 'en')) in rdf
     assert (a, SKOS.altLabel, Literal('longer', 'en')) in rdf
     assert (a, SKOS.altLabel, Literal('Longer', 'en')) in rdf
+
+
+def test_preflabel_uniqueness_alphanumeric():
+    rdf = Graph()
+    a = BNode()
+
+    rdf.add((a, RDF.type, SKOS.Concept))
+    rdf.add((a, SKOS.prefLabel, Literal('äaa', 'en')))  # keep
+    rdf.add((a, SKOS.prefLabel, Literal('Äba', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('aab', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('aba', 'en')))  # remove
+
+    rdf.add((a, SKOS.prefLabel, Literal('äa', 'fi')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('Äb', 'fi')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('aä', 'fi')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('ab', 'fi')))  # keep
+
+    len_before = len(rdf)
+
+    skosify.check.preflabel_uniqueness(rdf, policy=['shortest'])
+    assert len(rdf) == len_before
+    assert (a, SKOS.prefLabel, Literal('äaa', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Äba', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('aab', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('aba', 'en')) in rdf
+
+    assert (a, SKOS.prefLabel, Literal('ab', 'fi')) in rdf
+    assert (a, SKOS.altLabel, Literal('äa', 'fi')) in rdf
+    assert (a, SKOS.altLabel, Literal('Äb', 'fi')) in rdf
+    assert (a, SKOS.altLabel, Literal('aä', 'fi')) in rdf
+
+
+def test_preflabel_uniqueness_alphanumeric2():
+    rdf = Graph()
+    a = BNode()
+
+    rdf.add((a, RDF.type, SKOS.Concept))
+    rdf.add((a, SKOS.prefLabel, Literal('AAa', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('Aaa', 'en')))  # remove
+    rdf.add((a, SKOS.prefLabel, Literal('aaa', 'en')))  # keep
+    rdf.add((a, SKOS.prefLabel, Literal('Äää', 'en')))  # remove
+
+    len_before = len(rdf)
+
+    skosify.check.preflabel_uniqueness(rdf, policy=[])
+    assert len(rdf) == len_before
+    assert (a, SKOS.altLabel, Literal('AAa', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Aaa', 'en')) in rdf
+    assert (a, SKOS.prefLabel, Literal('aaa', 'en')) in rdf
+    assert (a, SKOS.altLabel, Literal('Äää', 'en')) in rdf


### PR DESCRIPTION
This PR fixes #81 by introducing a natural language sorting policy that will be appended to the policy list if applicable. I did not implement a reverse version of it as it would have needed a bit different approach and is not needed probably.

In case there is no sorter found for the turtle-based language code, the default, portable 'C' sorter will sort values alphanumerically (instead of user language sorter). This may or may not be wanted as empty literal tags will be sorted based on this.

Any thoughts, @osma ?