### PR TITLE
add post_update_query option

### DIFF
--- a/skosify/cli.py
+++ b/skosify/cli.py
@@ -55,10 +55,18 @@ def get_option_parser(defaults):
     group.add_option('--construct-query', type='string',
                      help='SPARQL CONSTRUCT query. '
                      'This query is executed against the input '
-                     'data and the result graph is used as the '
-                     'actual input. '
+                     'data (after possible --update-query) and '
+                     'the result graph is used as the actual input. '
                      'The value can be either the actual query, '
                      'or "@filename".')
+    group.add_option('--post-update-query', type='string',
+                     help='SPARQL update query. '
+                     'This convenience query is executed against '
+                     'the output data before writing it. '
+                     'The value can be either the actual query, '
+                     'or "@filename". '
+                     'Use at your own risk - output may not be '
+                     'SKOS at all.')
     group.add_option('-I', '--infer', action="store_true",
                      help='Perform RDFS subclass/subproperty inference '
                           'before transforming input.')

--- a/skosify/config.py
+++ b/skosify/config.py
@@ -76,6 +76,7 @@ class Config(object):
         self.infer = False
         self.update_query = None
         self.construct_query = None
+        self.post_update_query = None
 
         # mappings
         self.types = {}

--- a/skosify/skosify.py
+++ b/skosify/skosify.py
@@ -823,6 +823,10 @@ def skosify(*sources, **config):
     # check for duplicate labels
     check_labels(voc, config.preflabel_policy)
 
+    logging.debug("Phase 10: Performing post update query")
+    if config.post_update_query is not None:
+        transform_sparql_update(voc, config.post_update_query)
+
     processtime = time.time()
 
     logging.debug("reading input file took  %d seconds",
@@ -830,6 +834,6 @@ def skosify(*sources, **config):
     logging.debug("processing took          %d seconds",
                   (processtime - inputtime))
 
-    logging.debug("Phase 10: Writing output")
+    logging.debug("Phase 11: Writing output")
 
     return voc


### PR DESCRIPTION
Fixes #84 .

However, now that I made it I am a bit hesitant about the whole feature as this makes it possible to update the graph to a non-conforming SKOS.

Instead, I was thinking about the possibility to address the issue via the [pickle feature](https://docs.python.org/3/library/pickle.html) as it makes it possible to save or pipe the Python object (rdflib.Graph() in this case) directly to some other Python program for fast consuming in subsequent transformations made by more specific programs. This would mean changes in --output (and in related code parts), at least.

What do you think, @osma ?

P.S. Anyways, I finally found out that there was, after all, already an option for my use case so #84 may not be critical (even as an enhancement) at all and this whole issue may be ignored completely.