### PR TITLE
Upgrade pytest and switch to flake8

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,11 +5,7 @@
 [pytest]
 addopts =
     --verbose
-    --pep8
+    --flake8
     --cov=skosify
     --cov-report xml
     --cov-report term-missing
-pep8maxlinelength = 140
-pep8ignore =
-    test/*.py E501    # Allow long lines in tests
-    docs/*.py  E402   # import later

--- a/scripts/sparqldump.py
+++ b/scripts/sparqldump.py
@@ -99,11 +99,13 @@ def main():
     parser.add_option('-o', '--output', type='string', default='-',
                       help='Output file name. Default is "-" (stdout).')
     parser.add_option('-f', '--to-format', type='string', default='xml',
-                      help='Output format. Default is "xml". Possible values: xml, turtle. Not all endpoints will honor this setting.')
+                      help='Output format. Default is "xml". Possible values: xml, turtle. ' +
+                           'Not all endpoints will honor this setting.')
     parser.add_option('-g', '--graph', type='string',
                       help='Named graph to query. Default is none (i.e. use the default graph of the endpoint)')
     parser.add_option('-m', '--multiple', type='int',
-                      help='Perform multiple queries, with given number of triples each. Useful for endpoints that limit response size.')
+                      help='Perform multiple queries, with given number of triples each. ' +
+                           'Useful for endpoints that limit response size.')
     parser.add_option('-O', '--ordered', action='store_true',
                       help='Add ORDER BY in multiple mode. This may be heavy to process for the endpoint.')
     parser.add_option('-D', '--debug', action="store_true",

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,5 @@ test = pytest
 [bdist_wheel]
 universal = 1
 
+[flake8]
+max-line-length = 140

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ test = pytest
 universal = 1
 
 [flake8]
-max-line-length = 140
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='skosify',
       license='MIT',
       install_requires=['rdflib'],
       setup_requires=['rdflib>=4.2.2', 'pytest-runner>=2.9'],
-      tests_require=['pytest<6.0.0', 'pytest-pep8', 'pytest-cov', 'pytest-catchlog'],
+      tests_require=['pytest', 'pytest-flake8', 'pytest-cov', 'pytest-catchlog'],
       packages=['skosify', 'skosify.rdftools'],
       entry_points={'console_scripts': ['skosify=skosify.cli:main']}
       )

--- a/skosify/check.py
+++ b/skosify/check.py
@@ -2,7 +2,6 @@
 """Checks/fixes are bundled in one namespace."""
 
 import logging
-import time
 from rdflib.namespace import RDF, SKOS
 from .rdftools.namespace import SKOSEXT
 from .rdftools import localname, find_prop_overlap

--- a/skosify/cli.py
+++ b/skosify/cli.py
@@ -7,9 +7,6 @@ from .config import Config
 
 import optparse
 import logging
-import sys
-
-from rdflib import URIRef, Namespace, RDF, RDFS
 
 
 def get_option_parser(defaults):

--- a/skosify/config.py
+++ b/skosify/config.py
@@ -2,9 +2,6 @@
 """Store skosify configuration and read config file."""
 
 import logging
-import sys
-import argparse
-from rdflib import URIRef, Namespace, RDF, RDFS
 from io import StringIO
 from copy import copy
 from rdflib.namespace import URIRef, Namespace, RDF, RDFS, OWL, SKOS, DC, DCTERMS, XSD

--- a/skosify/rdftools/__init__.py
+++ b/skosify/rdftools/__init__.py
@@ -4,3 +4,7 @@
 from .io import read_rdf, write_rdf
 from .access import localname, find_prop_overlap
 from .modify import replace_subject, replace_predicate, replace_object, replace_uri, delete_uri
+
+__all__ = ['read_rdf', 'write_rdf', 'localname', 'find_prop_overlap',
+           'replace_subject', 'replace_predicate', 'replace_object',
+           'replace_uri', 'delete_uri']

--- a/skosify/skosify.py
+++ b/skosify/skosify.py
@@ -39,9 +39,9 @@ def mapping_get(uri, mapping):
             return v
     # 3. try to match local names with * prefix
     # try to match longest first, so sort the mapping by key length
-    l = list(mapping.items())
-    l.sort(key=lambda i: len(i[0]), reverse=True)
-    for k, v in l:
+    lst = list(mapping.items())
+    lst.sort(key=lambda i: len(i[0]), reverse=True)
+    for k, v in lst:
         if k[0] == '*' and ln.endswith(k[1:]):
             return v
     raise KeyError(uri)
@@ -54,7 +54,7 @@ def mapping_match(uri, mapping):
 
     """
     try:
-        val = mapping_get(uri, mapping)
+        _ = mapping_get(uri, mapping)
         return True
     except KeyError:
         return False
@@ -748,7 +748,7 @@ def skosify(*sources, **config):
     logging.debug("Phase 1: Parsing input files")
     try:
         voc = read_rdf(sources, config.from_format)
-    except:
+    except Exception:
         logging.critical("Parsing failed. Exception: %s",
                          str(sys.exc_info()[1]))
         sys.exit(1)

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -1,6 +1,4 @@
 # encoding=utf-8
-import unittest
-import pytest
 from rdflib import Graph, BNode, Literal
 from rdflib.namespace import RDF, SKOS
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,9 +1,8 @@
 # encoding=utf-8
 import unittest
-import pytest
 import logging
 from io import StringIO
-from rdflib import URIRef, Namespace
+from rdflib import URIRef
 
 import skosify
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -19,8 +19,8 @@ def expect_rdf(expect, graph):
 
 @pytest.mark.parametrize('infile', glob.glob('examples/*.in.*'))
 def test_example(infile):
-    outfile = re.sub('\.in\.([^.]+)$', r'.out.\1', infile)
-    conffile = re.sub('\.in\.[^.]+$', r'.cfg', infile)
+    outfile = re.sub(r'\.in\.([^.]+)$', r'.out.\1', infile)
+    conffile = re.sub(r'\.in\.[^.]+$', r'.cfg', infile)
 
     if os.path.isfile(conffile):
         config = skosify.config(conffile)

--- a/test/test_infer.py
+++ b/test/test_infer.py
@@ -1,8 +1,6 @@
 # encoding=utf-8
-import unittest
-import pytest
 from rdflib import Graph, BNode
-from rdflib.namespace import Namespace, RDF, RDFS, SKOS
+from rdflib.namespace import RDF, RDFS, SKOS
 
 import skosify
 


### PR DESCRIPTION
This PR updates from pytest 5.x to the newest available version (6.2.5 currently).
pytest-flake8 is used instead of deprecated pytest-pep8. Some errors/warnings found by flake8 were fixed as well.

Fixes #74 (the problem with test collection seems to have gone away with latest pytest)