### PR TITLE
Make prefLabel policies deterministic by using label string sort order to break ties

### DIFF
--- a/skosify/check.py
+++ b/skosify/check.py
@@ -147,7 +147,7 @@ def preflabel_uniqueness(rdf, policy='all'):
             return
 
     def key_fn(label):
-        return [policy_fn[p](label) for p in policies]
+        return [policy_fn[p](label) for p in policies] + [str(label)]
 
     for res in sorted(resources):
         prefLabels = {}


### PR DESCRIPTION
In issue #81, @kouralex pointed out that prefLabel selection policies are not deterministic in cases where there are ties - for example if two candidate labels have the same length when using the `shortest` policy. The proposed solution, implemented in #82, was to introduce locale-aware alphanumeric sorting as a separate policy. But there are problems in the approach of that PR because locale-aware sorting is a bit difficult to implement well.

This PR has narrower scope and only tries to fix the issue of nondeterministic selection. The simple fix is just to use the label itself (its string value) as the final key for sorting, when other policies such as `shortest` or `longest` cannot produce a single unambiguous result. The "winning" label may not be any better than the other candidates, but at least it's the same every time.