### PR TITLE
Add version option

### DIFF
--- a/skosify/cli.py
+++ b/skosify/cli.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 """Provides skosify as command line client."""
 
+from skosify import __version__ as version
 from skosify import skosify
 from .rdftools import write_rdf
 from .config import Config
@@ -17,7 +17,7 @@ def get_option_parser(defaults):
     # process command line parameters
     # e.g. skosify yso.owl -o yso-skos.rdf
     usage = "Usage: %prog [options] voc1 [voc2 ...]"
-    parser = optparse.OptionParser(usage=usage)
+    parser = optparse.OptionParser(usage=usage, version='v%s' % version)
     parser.set_defaults(**defaults)
     parser.add_option('-c', '--config', type='string',
                       help='Read default options '

--- a/skosify/skosify.py
+++ b/skosify/skosify.py
@@ -1,5 +1,3 @@
-# encoding=utf8
-
 import sys
 import time
 import logging
@@ -18,6 +16,7 @@ from .rdftools import (
     localname
 )
 
+from skosify import __version__ as version
 from .config import Config
 from . import infer, check
 
@@ -742,7 +741,7 @@ def skosify(*sources, **config):
     literalmap = config.literals
     relationmap = config.relations
 
-    logging.debug("Skosify starting. $Revision$")
+    logging.debug("Skosify %s starting.", version)
     starttime = time.time()
 
     logging.debug("Phase 1: Parsing input files")


### PR DESCRIPTION
Trivial fix since `optparse` has support for this built in.

Closes #92